### PR TITLE
Close #29: Improve matching

### DIFF
--- a/include/frame/matcher.hpp
+++ b/include/frame/matcher.hpp
@@ -33,9 +33,11 @@ public:
      * and `train` indices --- `frame2`.
      */
     std::vector<cv::DMatch> frameMatch(
-        std::shared_ptr<Frame> frame1, std::shared_ptr<Frame> frame2,
-        float maximumDistance, float areaSize = -1, int maxLevel = 4
-    );
+        const std::shared_ptr<KeyFrame>& keyframe1,
+        const std::shared_ptr<KeyFrame>& keyframe2,
+        float maximumDistance, float areaSize = -1, int maxLevel = 4,
+        bool withMappoints = true
+    ) const;
     /**
      * Find matches between KeyFrames.
      *
@@ -57,15 +59,15 @@ public:
      * and `train` indices --- `toKeyFrame`.
      */
     std::vector<cv::DMatch> projectionMatch(
-        std::shared_ptr<KeyFrame> fromKeyFrame,
-        std::shared_ptr<KeyFrame> toKeyFrame,
+        const std::shared_ptr<KeyFrame>& fromKeyFrame,
+        const std::shared_ptr<KeyFrame>& toKeyFrame,
         float maximumDistance, float areaSize = -1, int maxLevel = 4
-    );
+    ) const;
 private:
     std::vector<cv::Point2f> _projectMapPoints(
-        std::shared_ptr<KeyFrame> fromKeyFrame,
-        std::shared_ptr<KeyFrame> toKeyFrame
-    );
+        const std::shared_ptr<KeyFrame>& fromKeyFrame,
+        const std::shared_ptr<KeyFrame>& toKeyFrame
+    ) const;
 };
 
 };

--- a/include/frame/matcher.hpp
+++ b/include/frame/matcher.hpp
@@ -21,13 +21,19 @@ public:
     /**
      * Find matches between descriptors in given frames.
      *
-     * @param frame1 Frame which will be used to find matches with `frame2`.
-     * @param frame2 Frame which will be used to find mathces with `frame1`
+     * @param keyframe1 KeyFrame which will be used to find matches with keyframe2.
+     * @param keyframe2 KeyFrame which will be used to find mathces with keyframe1.
      * @param maximumDistance Maximum distance in terms of Hamming distance.
      * @param areaSize If you want to find matches for keypoints in an area
      * in terms of pixel distance between keypoints, then specify distance.
      * If you want to find matches between all keypoints,
      * no matter what pixel distace, specify `-1`.
+     * @param maxLevel KeyPoint matches whose `octave` is higher than
+     * this value will be discarded.
+     * @param withMappoints If `true`, finding matched will be done only
+     * using KeyPoints associated with MapPoints in keyframe1.
+     * This option is useful in tracking to speed up it.
+     * If `false` then matching will be done using all KeyPoints.
      * @return matches Output vector which will contain matches.
      * Where `query` indices are for the `frame1`
      * and `train` indices --- `frame2`.

--- a/include/tracking/tracker.hpp
+++ b/include/tracking/tracker.hpp
@@ -114,6 +114,13 @@ private:
      * Add mappoints to `keyframe` with `trainIdx` if there
      * is mappoint in `lastMappoints` under `queryIdx` key
      * from `matches`.
+     * @param checkMatches If `true`, then it will check if lastKeyFrame
+     * contains MapPoint under `queryIdx`.
+     * Otherwise it will not check.
+     * You can disable checking if you've done frame matching
+     * `withMappoints` set to `true` or projection matching,
+     * since they guaratee that all matches have respectful MapPoints
+     * in lastKeyFrame.
      */
     void _addMatches(
         std::shared_ptr<KeyFrame>& keyframe,

--- a/include/tracking/tracker.hpp
+++ b/include/tracking/tracker.hpp
@@ -24,9 +24,7 @@ public:
     };
 public:
     std::shared_ptr<cv::Mat> cameraMatrix, distortions;
-
     std::shared_ptr<KeyFrame> lastKeyFrame, currentKeyFrame;
-
     std::shared_ptr<Detector> detector;
     Matcher matcher;
     Mapper mapper;
@@ -118,9 +116,10 @@ private:
      * from `matches`.
      */
     void _addMatches(
-        std::shared_ptr<KeyFrame> keyframe,
-        std::map<int, std::shared_ptr<MapPoint>>& lastMappoints,
-        const std::vector<cv::DMatch>& matches
+        std::shared_ptr<KeyFrame>& keyframe,
+        const std::shared_ptr<KeyFrame>& lastKeyframe,
+        const std::vector<cv::DMatch>& matches,
+        bool checkMatches = false
     );
     void _removeMatches(std::shared_ptr<KeyFrame> keyframe);
     /**

--- a/main.cpp
+++ b/main.cpp
@@ -76,14 +76,11 @@ void drawMap(std::shared_ptr<slam::Map> map) {
 }
 
 cv::Mat drawMatches(
-    std::shared_ptr<slam::KeyFrame> keyframe1,
-    std::shared_ptr<slam::KeyFrame> keyframe2
+    const std::shared_ptr<slam::KeyFrame>& keyframe1,
+    const std::shared_ptr<slam::KeyFrame>& keyframe2,
+    const slam::Tracker& tracker
 ) {
-    slam::Matcher matcher;
-
-    auto matches = matcher.frameMatch(
-        keyframe1->getFrame(), keyframe2->getFrame(), 300, 50
-    );
+    auto matches = tracker.matcher.frameMatch(keyframe1, keyframe2, 300, 50, false);
 
     cv::Mat matchImg;
     cv::drawMatches(
@@ -96,7 +93,6 @@ cv::Mat drawMatches(
     );
 
     return matchImg;
-
 }
 
 int main() {

--- a/src/frame/matcher.cpp
+++ b/src/frame/matcher.cpp
@@ -11,80 +11,128 @@ namespace slam {
 Matcher::Matcher(cv::Ptr<cv::BFMatcher> matcher) : matcher(matcher) {}
 
 std::vector<cv::DMatch> Matcher::frameMatch(
-    std::shared_ptr<Frame> frame1, std::shared_ptr<Frame> frame2,
-    float maximumDistance, float areaSize, int maxLevel
-) {
-    std::vector<cv::DMatch> matches, descriptorMatches;
-    bool inArea, checkArea = areaSize != -1;
-    cv::Point2f d;
-
-    matcher->match(
-        *frame1->descriptors, *frame2->descriptors, descriptorMatches
-    );
-    for (auto& m : descriptorMatches) {
-        if (
-            maxLevel != -1
-            && frame1->undistortedKeypoints[m.queryIdx].octave > maxLevel
-        ) continue;
-        if (checkArea) {
-            d = (
-                frame1->undistortedKeypoints[m.queryIdx].pt
-                - frame2->undistortedKeypoints[m.trainIdx].pt
-            );
-            inArea = abs(d.x) < areaSize && abs(d.y) < areaSize;
-        } else inArea = true;
-
-        if (inArea && m.distance < maximumDistance)
-            matches.push_back(m);
+    const std::shared_ptr<KeyFrame>& keyframe1,
+    const std::shared_ptr<KeyFrame>& keyframe2,
+    float maximumDistance, float areaSize, int maxLevel, bool withMappoints
+) const {
+    const auto& frame1 = keyframe1->getFrame(), frame2 = keyframe2->getFrame();
+    // Select descriptors for existing mappoints in `keyframe1`.
+    cv::Mat descriptors1;
+    std::vector<cv::KeyPoint> keypoints1;
+    std::vector<int> idMapping;
+    if (withMappoints) {
+        descriptors1 = cv::Mat(static_cast<int>(keyframe1->mappoints.size()), 32, CV_8U);
+        int rowId = 0;
+        for (const auto& [id, mappoint] : keyframe1->mappoints) {
+            idMapping.push_back(id);
+            keypoints1.push_back(frame1->undistortedKeypoints[id]);
+            const auto& row = frame1->descriptors->row(id);
+            for (int i = 0; i < 32; i++)
+                descriptors1.at<uchar>(rowId, i) = row.at<uchar>(0, i);
+            ++rowId;
+        }
+    } else {
+        descriptors1 = *frame1->descriptors;
+        keypoints1 = frame1->undistortedKeypoints;
     }
-
-    return matches;
+    // Find matches.
+    std::vector<cv::DMatch> finalMatches;
+    std::vector<std::vector<cv::DMatch>> descriptorMatches;
+    matcher->radiusMatch(
+        descriptors1, *frame2->descriptors, descriptorMatches, maximumDistance
+    );
+    // Filter out matches by pixel-distance and keypoint's octave.
+    cv::Point2f distance;
+    bool checkArea = areaSize != -1;
+    for (const auto& matches : descriptorMatches) {
+        if (matches.empty()) continue;
+        const auto& keypoint1 = keypoints1[matches[0].queryIdx];
+        for (const auto& match : matches) {
+            if (
+                maxLevel != -1
+                && keypoint1.octave > maxLevel
+                && frame2->undistortedKeypoints[match.trainIdx].octave > maxLevel
+            ) continue;
+            if (!checkArea) {
+                finalMatches.push_back(match);
+                break;
+            }
+            distance = (
+                keypoint1.pt - frame2->undistortedKeypoints[match.trainIdx].pt
+            );
+            if (abs(distance.x) < areaSize && abs(distance.y) < areaSize) {
+                finalMatches.push_back(match);
+                break;
+            }
+        }
+    }
+    if (withMappoints) // Map query matches to `keyframe1` original KeyPoints.
+        for (auto& match : finalMatches) match.queryIdx = idMapping[match.queryIdx];
+    return finalMatches;
 }
 
 std::vector<cv::DMatch> Matcher::projectionMatch(
-    std::shared_ptr<KeyFrame> fromKeyFrame,
-    std::shared_ptr<KeyFrame> toKeyFrame,
+    const std::shared_ptr<KeyFrame>& fromKeyFrame,
+    const std::shared_ptr<KeyFrame>& toKeyFrame,
     float maximumDistance, float areaSize, int maxLevel
-) {
-    auto projectedKeyPoints = _projectMapPoints(fromKeyFrame, toKeyFrame);
-    std::vector<cv::DMatch> rawMatches, matches;
-    matcher->match(
-        *fromKeyFrame->getFrame()->descriptors,
-        *toKeyFrame->getFrame()->descriptors,
-        rawMatches
-    );
-
-    const bool checkArea = areaSize != -1;
-    bool inArea; cv::Point2f diff, kp;
-    const auto& toFrame = toKeyFrame->getFrame();
-    for (const auto& m : rawMatches) {
-        if (
-            maxLevel != -1
-            && toFrame->undistortedKeypoints[m.trainIdx].octave > maxLevel
-        ) continue;
-        if (m.distance > maximumDistance) continue;
-        // Check if matched `toKeyFrame` keypoint is in any of the
-        // areas of `areaSize` around projected `fromKeyFrame` mappoints
-        // to `toKeyFrame` image plane. Select only those matches.
-        if (checkArea) {
-            inArea = false;
-            kp = toFrame->undistortedKeypoints[m.trainIdx].pt;
-            for (const auto& pp : projectedKeyPoints) {
-                if (inArea) break;
-                diff = kp - pp;
-                inArea = abs(diff.x) < areaSize && abs(diff.y) < areaSize;
-            }
-            if (!inArea) continue;
-        }
-        matches.push_back(m);
+) const {
+    const auto& frame1 = fromKeyFrame->getFrame(), frame2 = toKeyFrame->getFrame();
+    // Select descriptors for existing mappoints in `keyframe1`.
+    cv::Mat descriptors1(static_cast<int>(fromKeyFrame->mappoints.size()), 32, CV_8U);
+    std::vector<cv::KeyPoint> keypoints1;
+    std::vector<int> idMapping;
+    int rowId = 0;
+    for (const auto& [id, mappoint] : fromKeyFrame->mappoints) {
+        idMapping.push_back(id);
+        keypoints1.push_back(frame1->undistortedKeypoints[id]);
+        const auto& row = frame1->descriptors->row(id);
+        for (int i = 0; i < 32; i++)
+            descriptors1.at<uchar>(rowId, i) = row.at<uchar>(0, i);
+        ++rowId;
     }
-    return matches;
+    // Find matches.
+    std::vector<cv::DMatch> finalMatches;
+    std::vector<std::vector<cv::DMatch>> descriptorMatches;
+    matcher->radiusMatch(
+        descriptors1, *frame2->descriptors, descriptorMatches, maximumDistance
+    );
+    // Project `fromKeyFrame`'s mappoint into `toKeyFrame`'s image plane.
+    auto projectedKeyPoints = _projectMapPoints(fromKeyFrame, toKeyFrame);
+    // Filter out matches by pixel-distance and keypoint's octave.
+    cv::Point2f distance;
+    bool checkArea = areaSize != -1;
+    for (const auto& matches : descriptorMatches) {
+        if (matches.empty()) continue;
+        const auto& keypoint1 = keypoints1[matches[0].queryIdx];
+        const auto& projectedPoint = projectedKeyPoints[matches[0].queryIdx];
+        for (const auto& match : matches) {
+            if (
+                maxLevel != -1
+                && keypoint1.octave > maxLevel
+                && frame2->undistortedKeypoints[match.trainIdx].octave > maxLevel
+            ) continue;
+            if (!checkArea) {
+                finalMatches.push_back(match);
+                break;
+            }
+            distance = (
+                projectedPoint - frame2->undistortedKeypoints[match.trainIdx].pt
+            );
+            if (abs(distance.x) < areaSize && abs(distance.y) < areaSize) {
+                finalMatches.push_back(match);
+                break;
+            }
+        }
+    }
+    // Map query matches to `keyframe1` original KeyPoints.
+    for (auto& match : finalMatches) match.queryIdx = idMapping[match.queryIdx];
+    return finalMatches;
 }
 
 std::vector<cv::Point2f> Matcher::_projectMapPoints(
-    std::shared_ptr<KeyFrame> fromKeyFrame,
-    std::shared_ptr<KeyFrame> toKeyFrame
-) {
+    const std::shared_ptr<KeyFrame>& fromKeyFrame,
+    const std::shared_ptr<KeyFrame>& toKeyFrame
+) const {
     cv::Mat rotation, translation;
     auto currentPose = toKeyFrame->getPose();
     cv::Rodrigues(currentPose.rowRange(0, 3).colRange(0, 3), rotation);
@@ -101,7 +149,6 @@ std::vector<cv::Point2f> Matcher::_projectMapPoints(
         *toKeyFrame->getFrame()->distortions,
         points
     );
-
     return points;
 }
 

--- a/src/tracking/mapper.cpp
+++ b/src/tracking/mapper.cpp
@@ -31,9 +31,7 @@ bool Mapper::initialize() {
     auto initial = keyframeQueue.front(); keyframeQueue.pop();
     current = keyframeQueue.front(); keyframeQueue.pop();
 
-    auto matches = matcher.frameMatch(
-        initial->getFrame(), current->getFrame(), 300, 50
-    );
+    auto matches = matcher.frameMatch(initial, current, 300, -1, 4, false);
     if (matches.size() < 100) return false;
     auto [reconstructedPoints, pose, mask] = std::get<0>(triangulatePoints(
         initial, current, matches, true
@@ -92,13 +90,9 @@ void Mapper::process() {
     // new MapPoints to the map if they pass outliers test.
     for (auto& connection : current->connections) {
         auto keyframe = connection.first;
-        auto matches = matcher.frameMatch(
-            keyframe->getFrame(), current->getFrame(), 300, -1
-        );
+        auto matches = matcher.frameMatch(keyframe, current, 300, -1, 4, false);
         if (matches.size() < 10) continue;
-        auto points = std::get<1>(triangulatePoints(
-            keyframe, current, matches, false
-        ));
+        auto points = std::get<1>(triangulatePoints(keyframe, current, matches, false));
 
         for (size_t i = 0; i < matches.size(); i++) {
             auto point = points[i]; auto match = matches[i];


### PR DESCRIPTION
- Add ability to match using only `KeyPoints` associated with created `MapPoints`
- Fix bug in frame tracking (when using projection match, new matches weren't added)