### PR TITLE
Close #34: Improve connection creation

### DIFF
--- a/include/frame/matcher.hpp
+++ b/include/frame/matcher.hpp
@@ -41,7 +41,7 @@ public:
     std::vector<cv::DMatch> frameMatch(
         const std::shared_ptr<KeyFrame>& keyframe1,
         const std::shared_ptr<KeyFrame>& keyframe2,
-        float maximumDistance, float areaSize = -1, int maxLevel = 4,
+        float maximumDistance = 300, float areaSize = -1, int maxLevel = 4,
         bool withMappoints = true
     ) const;
     /**
@@ -67,7 +67,7 @@ public:
     std::vector<cv::DMatch> projectionMatch(
         const std::shared_ptr<KeyFrame>& fromKeyFrame,
         const std::shared_ptr<KeyFrame>& toKeyFrame,
-        float maximumDistance, float areaSize = -1, int maxLevel = 4
+        float maximumDistance = 300, float areaSize = -1, int maxLevel = 4
     ) const;
 private:
     std::vector<cv::Point2f> _projectMapPoints(

--- a/include/frame/matcher.hpp
+++ b/include/frame/matcher.hpp
@@ -41,8 +41,41 @@ public:
     std::vector<cv::DMatch> frameMatch(
         const std::shared_ptr<KeyFrame>& keyframe1,
         const std::shared_ptr<KeyFrame>& keyframe2,
-        float maximumDistance = 300, float areaSize = -1, int maxLevel = 4,
-        bool withMappoints = true
+        const std::vector<int>& ids,
+        float maximumDistance = 300, float areaSize = -1, int maxLevel = 4
+    ) const;
+    /**
+     * Find matches among KeyPoints that have corresponding MapPoints.
+     * This can be useful when performing tracking or sharing MapPoints
+     * between KeyFrames as we only need to match against KeyPoints with
+     * MapPoints.
+     *
+     * @keyframe1 KeyFrame from which to take KeyPoints with MapPoints to match.
+     * Only MapPoints from this KeyFrame will be taken into account.
+     * @keyframe2 KeyFrame which will be matched against `keyframe1`.
+     *
+     * For other parameters see Matcher.frameMatch method.
+     */
+    std::vector<cv::DMatch> mappointsFrameMatch(
+        const std::shared_ptr<KeyFrame>& keyframe1,
+        const std::shared_ptr<KeyFrame>& keyframe2,
+        float maximumDistance = 300, float areaSize = -1, int maxLevel = 4
+    ) const;
+    /**
+     * Find matches among KeyPoints that does not have corresponding MapPoints.
+     * This can be useful when we need to find more matches for the KeyFrame
+     * that already has some MapPoints attached to it.
+     *
+     * @keyframe1 KeyFrame for which to avoid KeyPoints with MapPoints.
+     * Only MapPoints from this KeyFrame will be taken into account.
+     * @keyframe2 KeyFrame which will be matched against `keyframe1`.
+     *
+     * For other parameters see Matcher.frameMatch method.
+     */
+    std::vector<cv::DMatch> inverseMappointsFrameMatch(
+        const std::shared_ptr<KeyFrame>& keyframe1,
+        const std::shared_ptr<KeyFrame>& keyframe2,
+        float maximumDistance = 300, float areaSize = -1, int maxLevel = 4
     ) const;
     /**
      * Find matches between KeyFrames.
@@ -70,10 +103,17 @@ public:
         float maximumDistance = 300, float areaSize = -1, int maxLevel = 4
     ) const;
 private:
-    std::vector<cv::Point2f> _projectMapPoints(
+    static std::vector<cv::DMatch> _filterMatches(
+        const std::vector<cv::KeyPoint>& keypoints1,
+        const std::vector<cv::KeyPoint>& keypoints2,
+        const std::vector<std::vector<cv::DMatch>>& rawMatches,
+        float areaSize, int maxLevel
+    );
+
+    static std::vector<cv::Point2f> _projectMapPoints(
         const std::shared_ptr<KeyFrame>& fromKeyFrame,
         const std::shared_ptr<KeyFrame>& toKeyFrame
-    ) const;
+    );
 };
 
 };

--- a/include/map/mappoint.hpp
+++ b/include/map/mappoint.hpp
@@ -21,6 +21,8 @@ private:
      */
     cv::Point3f position;
 public:
+    static unsigned long long globalID;
+    unsigned long long id;
     /**
      * Main KeyFrame from which this MapPoint was created.
      */

--- a/include/map/mappoint.hpp
+++ b/include/map/mappoint.hpp
@@ -61,7 +61,7 @@ public:
      * @param id Id of the keypoint in `keyframeO`
      * which corresponds to this MapPoint.
      */
-    void addObservation(std::shared_ptr<KeyFrame> keyframeO, int id);
+    void addObservation(std::shared_ptr<KeyFrame> keyframeO, int idO);
     void removeObservation(std::shared_ptr<KeyFrame> keyframeO);
 };
 

--- a/include/tracking/mapper.hpp
+++ b/include/tracking/mapper.hpp
@@ -20,6 +20,7 @@ class Mapper {
 private:
     std::shared_ptr<KeyFrame> current;
     std::queue<std::shared_ptr<KeyFrame>> keyframeQueue;
+    int lastReconstruction = 0;
 
     Matcher matcher;
 public:

--- a/include/tracking/mapper.hpp
+++ b/include/tracking/mapper.hpp
@@ -69,7 +69,16 @@ private:
         std::shared_ptr<KeyFrame> keyframe, int threshold = 15
     );
     /**
-     * TODO doc
+     * Share existing MapPoints in `keyframe` connections
+     * to facilitate MapPoint reusability.
+     *
+     * @param keyframe KeyFrame with which MapPoints will be shared.
+     * @param matchRelation Match relation for `keyframe` and its connection.
+     * If amount of matches is greater than
+     * `matchRelation * connection.mappointsNumber()` then MapPoints of
+     * this connection will be shared with `keyframe`.
+     * @return `true` if enough MapPoints were shared with `keyframe`
+     * among all its connections. `false` --- otherwise.
      */
     bool _share(std::shared_ptr<KeyFrame>& keyframe, float matchRelation = 0.3f);
     /**

--- a/include/tracking/mapper.hpp
+++ b/include/tracking/mapper.hpp
@@ -68,7 +68,13 @@ private:
     void _createConnections(
         std::shared_ptr<KeyFrame> keyframe, int threshold = 15
     );
-
+    /**
+     * TODO doc
+     */
+    bool _share(std::shared_ptr<KeyFrame>& keyframe, float matchRelation = 0.3f);
+    /**
+     * TODO doc
+     */
     static std::tuple<cv::Mat, cv::Mat> _recoverPose(
         std::vector<cv::Point2f>& frame1Points,
         std::vector<cv::Point2f>& frame2Points,

--- a/main.cpp
+++ b/main.cpp
@@ -80,7 +80,7 @@ cv::Mat drawMatches(
     const std::shared_ptr<slam::KeyFrame>& keyframe2,
     const slam::Tracker& tracker
 ) {
-    auto matches = tracker.matcher.frameMatch(keyframe1, keyframe2, 300, 50, false);
+    auto matches = tracker.matcher.frameMatch(keyframe1, keyframe2, {}, 300, 50);
 
     cv::Mat matchImg;
     cv::drawMatches(

--- a/src/frame/matcher.cpp
+++ b/src/frame/matcher.cpp
@@ -84,8 +84,7 @@ std::vector<cv::DMatch> Matcher::inverseMappointsFrameMatch(
         ids.begin(), ids.end(), mappointIds.begin(), mappointIds.end(),
         std::inserter(matchIds, matchIds.begin())
     );
-    ids = matchIds;
-    return frameMatch(keyframe1, keyframe2, ids, maximumDistance, areaSize, maxLevel);
+    return frameMatch(keyframe1, keyframe2, matchIds, maximumDistance, areaSize, maxLevel);
 }
 
 std::vector<cv::DMatch> Matcher::projectionMatch(

--- a/src/frame/matcher.cpp
+++ b/src/frame/matcher.cpp
@@ -96,11 +96,12 @@ std::vector<cv::DMatch> Matcher::projectionMatch(
     matcher->radiusMatch(
         descriptors1, *frame2->descriptors, descriptorMatches, maximumDistance
     );
-    // Project `fromKeyFrame`'s mappoint into `toKeyFrame`'s image plane.
-    auto projectedKeyPoints = _projectMapPoints(fromKeyFrame, toKeyFrame);
+    bool checkArea = areaSize != -1;
+    std::vector<cv::Point2f> projectedKeyPoints;
+    if (checkArea) // Project `fromKeyFrame`'s mappoint into `toKeyFrame`'s image plane.
+        projectedKeyPoints = _projectMapPoints(fromKeyFrame, toKeyFrame);
     // Filter out matches by pixel-distance and keypoint's octave.
     cv::Point2f distance;
-    bool checkArea = areaSize != -1;
     for (const auto& matches : descriptorMatches) {
         if (matches.empty()) continue;
         const auto& keypoint1 = keypoints1[matches[0].queryIdx];

--- a/src/map/mappoint.cpp
+++ b/src/map/mappoint.cpp
@@ -10,8 +10,10 @@
 
 namespace slam {
 
+unsigned long long MapPoint::globalID = 0;
+
 MapPoint::MapPoint(const cv::Point3f& position, std::shared_ptr<KeyFrame> keyframe)
-    : position(position), keyframe(keyframe) {}
+    : id(globalID++), position(position), keyframe(keyframe) {}
 
 cv::Point3f MapPoint::getWorldPos() const { return position; }
 

--- a/src/map/mappoint.cpp
+++ b/src/map/mappoint.cpp
@@ -1,8 +1,9 @@
 #pragma warning(push, 0)
 #include<iostream>
 
-#include<opencv2/core/cvdef.h>
 #include<opencv2/calib3d.hpp>
+#include<opencv2/core/cvdef.h>
+#include<opencv2/core/softfloat.hpp>
 #pragma warning(pop)
 
 #include"converter.hpp"
@@ -27,8 +28,8 @@ std::map<std::shared_ptr<KeyFrame>, int> MapPoint::getObservations() const {
     return observations;
 }
 
-void MapPoint::addObservation(std::shared_ptr<KeyFrame> keyframeO, int id) {
-    observations[keyframeO] = id;
+void MapPoint::addObservation(std::shared_ptr<KeyFrame> keyframeO, int idO) {
+    observations[keyframeO] = idO;
 }
 
 void MapPoint::removeObservation(std::shared_ptr<KeyFrame> keyframeO) {
@@ -56,6 +57,7 @@ bool isOutlier(
     const std::shared_ptr<KeyFrame>& trainKeyframe,
     const cv::DMatch& match
 ) {
+    if (std::isnan(point.x)) return true;
     auto pointMat = matFromPoint3f(point).t();
     // Check that parallax for a point lies in (0, 1) range.
     // Otherwise point considered an outlier and discarded.
@@ -95,8 +97,7 @@ double projectionError(
     );
 
     auto target = keyframe->getFrame()->undistortedKeypoints[keypointId].pt;
-    auto p = cv::norm(target - projection[0]);
-    return p;
+    return cv::norm(target - projection[0]);
 }
 
 };

--- a/src/tracking/mapper.cpp
+++ b/src/tracking/mapper.cpp
@@ -105,6 +105,9 @@ void Mapper::process() {
     // For each connection triangulate matches and add
     // new MapPoints to the map if they pass outliers test.
     for (auto& connection : current->connections) {
+        // If enough MapPoints, add no more.
+        if (current->mappointsNumber() >= 200) break;
+        // Otherwise, add some more.
         auto keyframe = connection.first;
         auto matches = matcher.inverseMappointsFrameMatch(current, keyframe);
         if (matches.size() < 10) continue;

--- a/src/tracking/tracker.cpp
+++ b/src/tracking/tracker.cpp
@@ -73,10 +73,10 @@ void Tracker::track(std::shared_ptr<cv::Mat> image) {
 bool Tracker::_trackFrame() {
     std::cout << "[tracking] Frame" << std::endl;
     // Add matched mappoints to current keyframe.
-    auto matches = matcher.frameMatch(lastKeyFrame, currentKeyFrame, 300, 50);
+    auto matches = matcher.mappointsFrameMatch(lastKeyFrame, currentKeyFrame, 300, 50);
     _addMatches(currentKeyFrame, lastKeyFrame, matches);
     if (currentKeyFrame->mappointsNumber() < 30) {
-        matches = matcher.frameMatch(lastKeyFrame, currentKeyFrame, 300, -1, -1);
+        matches = matcher.mappointsFrameMatch(lastKeyFrame, currentKeyFrame, 300, -1, -1);
         _addMatches(currentKeyFrame, lastKeyFrame, matches);
     }
     std::cout


### PR DESCRIPTION
- Implement MapPoint sharing
- Implement matching with different setups
  - Matching with mappoints
  - Matching with only with keypoints without mappoints
- Limit number of connections used for mapping
(no need to triangulate with all connections)